### PR TITLE
Undefined name: ResampleDataset

### DIFF
--- a/pywick/datasets/data_utils.py
+++ b/pywick/datasets/data_utils.py
@@ -166,7 +166,7 @@ def _finds_inputs_and_targets(root, class_mode, class_to_idx=None, input_regex='
 
     :return: partition1 (list of (input, target)), partition2 (list of (input, target))
     """
-    if class_mode is not 'image' and class_mode is not 'label' and class_mode is not 'path':
+    if class_mode not in ('image', 'label', 'path'):
         raise ValueError('class_mode must be one of: {label, image, path}')
 
     if class_mode == 'image' and rel_target_root == '' and target_prefix == '' and target_postfix == '':

--- a/pywick/datasets/tnt/shuffledataset.py
+++ b/pywick/datasets/tnt/shuffledataset.py
@@ -1,4 +1,4 @@
-from pywick.datasets.tnt.dataset import Dataset
+from pywick.datasets.tnt.resampledataset import ResampleDataset
 import torch
 
 

--- a/pywick/models/classification/dpn/dualpath.py
+++ b/pywick/models/classification/dpn/dualpath.py
@@ -215,10 +215,10 @@ class DualPathBlock(nn.Module):
         self.num_1x1_c = num_1x1_c
         self.inc = inc
         self.b = b
-        if block_type is 'proj':
+        if block_type == 'proj':
             self.key_stride = 1
             self.has_proj = True
-        elif block_type is 'down':
+        elif block_type == 'down':
             self.key_stride = 2
             self.has_proj = True
         else:


### PR DESCRIPTION
$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./pywick/models/classification/dpn/dualpath.py:218:12: F632 use ==/!= to compare str, bytes, and int literals
        if block_type is 'proj':
           ^
./pywick/models/classification/dpn/dualpath.py:221:14: F632 use ==/!= to compare str, bytes, and int literals
        elif block_type is 'down':
             ^
./pywick/models/classification/dpn/dualpath.py:225:20: F632 use ==/!= to compare str, bytes, and int literals
            assert block_type is 'normal'
                   ^
./pywick/datasets/data_utils.py:169:8: F632 use ==/!= to compare str, bytes, and int literals
    if class_mode is not 'image' and class_mode is not 'label' and class_mode is not 'path':
       ^
./pywick/datasets/data_utils.py:169:38: F632 use ==/!= to compare str, bytes, and int literals
    if class_mode is not 'image' and class_mode is not 'label' and class_mode is not 'path':
                                     ^
./pywick/datasets/data_utils.py:169:68: F632 use ==/!= to compare str, bytes, and int literals
    if class_mode is not 'image' and class_mode is not 'label' and class_mode is not 'path':
                                                                   ^
./pywick/datasets/tnt/shuffledataset.py:5:22: F821 undefined name 'ResampleDataset'
class ShuffleDataset(ResampleDataset):
                     ^
6     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'ResampleDataset'
7
```